### PR TITLE
feat: new local docker stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+vendor/
+node_modules/
+.cache/
+.idea/

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ LOCAL_PHP_XDEBUG=false
 LOCAL_PHP_XDEBUG_MODE=develop,debug
 
 # Whether or not to enable Memcached.
+# NOTE: memcache is currently not supported in waggypuppy local dev.  Leave this value at 'false'.
 LOCAL_PHP_MEMCACHED=false
 
 ##
@@ -41,19 +42,19 @@ LOCAL_PHP_MEMCACHED=false
 #
 # Supported values are `mysql` and `mariadb`.
 ##
+# NOTE: only mysql is currently supported in waggypuppy local dev.  Leave this value at 'mysql'.
 LOCAL_DB_TYPE=mysql
 
 ##
 # The database version to use.
 #
 # Defaults to 8.0 with the assumption that LOCAL_DB_TYPE is set to `mysql` above.
-#
-# When using `mysql`, see https://hub.docker.com/_/mysql for valid versions.
-# When using `mariadb`, see https://hub.docker.com/_/mariadb for valid versions.
 ##
+# NOTE: waggypuppy uses a hardwired version of mysql (8.0).  Leave this value at '8.0'
 LOCAL_DB_VERSION=8.0
 
 # Whether or not to enable multisite.
+# NOTE: multisite is currently not supported in waggypuppy local dev.  Leave this value at 'false'.
 LOCAL_MULTISITE=false
 
 # The debug settings to add to `wp-config.php`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,69 +1,33 @@
 services:
-
-  ##
-  # The web server container.
-  ##
-  wordpress-develop:
-    image: nginx:alpine
-
-    networks:
-      - wpdevnet
-
-    ports:
-      - ${LOCAL_PORT-8889}:80
-
-    environment:
-      LOCAL_DIR: ${LOCAL_DIR-src}
-
-    volumes:
-      - ./tools/local-env/default.template:/etc/nginx/conf.d/default.template
-      - ./:/var/www
-
-    # Load our config file, substituting environment variables into the config.
-    command: /bin/sh -c "envsubst '$$LOCAL_DIR' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"
-
-    depends_on:
-      php:
-        condition: service_started
-      mysql:
-        condition: service_healthy
-
-  ##
-  # The PHP container.
-  ##
   php:
-    image: wordpressdevelop/php:${LOCAL_PHP-latest}
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
 
-    networks:
-      - wpdevnet
+    working_dir: /var/www/src
+
+    command: ['php', '-S', '0.0.0.0:8889']
 
     environment:
       - LOCAL_PHP_XDEBUG=${LOCAL_PHP_XDEBUG-false}
       - XDEBUG_MODE=${LOCAL_PHP_XDEBUG_MODE-develop,debug}
       - LOCAL_PHP_MEMCACHED=${LOCAL_PHP_MEMCACHED-false}
-      - PHP_FPM_UID=${PHP_FPM_UID-1000}
-      - PHP_FPM_GID=${PHP_FPM_GID-1000}
       - GITHUB_REF=${GITHUB_REF-false}
       - GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME-false}
 
+    networks:
+      - wpdevnet
+
     volumes:
-      - ./tools/local-env/php-config.ini:/usr/local/etc/php/conf.d/php-config.ini
+      - ./docker/php-config.ini:/usr/local/etc/php/conf.d/php-config.ini
+      - ./docker/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
       - ./:/var/www
 
-    # Copy or delete the Memcached dropin plugin file as appropriate.
-    command: /bin/sh -c "if [ $LOCAL_PHP_MEMCACHED = true ]; then cp -n /var/www/tests/phpunit/includes/object-cache.php /var/www/src/wp-content/object-cache.php; else rm -f /var/www/src/wp-content/object-cache.php; fi && exec php-fpm"
+    ports:
+      - "8889:8889"
 
-    # The init directive ensures the command runs with a PID > 1, so Ctrl+C works correctly.
-    init: true
-
-    extra_hosts:
-      - localhost:host-gateway
-
-  ##
-  # The MySQL container.
-  ##
   mysql:
-    image: ${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
+    image: mysql/mysql-server:8.0
 
     networks:
       - wpdevnet
@@ -72,72 +36,23 @@ services:
       - "3306"
 
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: 'password'
+      MYSQL_ROOT_HOST: '%'
 
     volumes:
       - ./tools/local-env/mysql-init.sql:/docker-entrypoint-initdb.d/mysql-init.sql
       - mysql:/var/lib/mysql
 
-    # For compatibility with PHP versions that don't support the caching_sha2_password auth plugin used in MySQL 8.0.
     command: --default-authentication-plugin=mysql_native_password
 
     healthcheck:
-      test: [ "CMD-SHELL", "if [ \"$LOCAL_DB_TYPE\" = \"mariadb\" ]; then mariadb-admin ping -h localhost; else mysqladmin ping -h localhost; fi" ]
+      test: [ "CMD-SHELL", "mysqladmin ping -h localhost" ]
       timeout: 5s
       interval: 5s
       retries: 10
 
-  ##
-  # The WP CLI container.
-  ##
-  cli:
-    image: wordpressdevelop/cli:${LOCAL_PHP-latest}
-
-    networks:
-      - wpdevnet
-
-    environment:
-      - LOCAL_PHP_XDEBUG=${LOCAL_PHP_XDEBUG-false}
-      - LOCAL_PHP_MEMCACHED=${LOCAL_PHP_MEMCACHED-false}
-      - PHP_FPM_UID=${PHP_FPM_UID-1000}
-      - PHP_FPM_GID=${PHP_FPM_GID-1000}
-
-    volumes:
-      - ./:/var/www
-
-    # The init directive ensures the command runs with a PID > 1, so Ctrl+C works correctly.
-    init: true
-
-    extra_hosts:
-      - localhost:host-gateway
-
-    depends_on:
-      php:
-        condition: service_started
-      mysql:
-        condition: service_healthy
-
-  ##
-  # The Memcached container.
-  ##
-  memcached:
-    image: memcached
-
-    networks:
-      - wpdevnet
-
-    ports:
-      - 11211:11211
-
-    depends_on:
-      php:
-        condition: service_started
-
 volumes:
-  # So that sites aren't wiped every time containers are restarted, MySQL uses a persistent volume.
-  mysql: {}
+  mysql: ~
 
 networks:
-  # Creating our own network allows us to connect between containers using their service name.
-  wpdevnet:
-    driver: bridge
+  wpdevnet: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     environment:
       - LOCAL_PHP_XDEBUG=${LOCAL_PHP_XDEBUG-false}
       - XDEBUG_MODE=${LOCAL_PHP_XDEBUG_MODE-develop,debug}
-      - LOCAL_PHP_MEMCACHED=${LOCAL_PHP_MEMCACHED-false}
       - GITHUB_REF=${GITHUB_REF-false}
       - GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME-false}
 
@@ -50,6 +49,25 @@ services:
       timeout: 5s
       interval: 5s
       retries: 10
+
+  cli:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+
+    profiles: ['cli']
+
+    working_dir: /var/www/src
+
+    entrypoint: ['/usr/local/bin/wp', '--allow-root']
+
+    networks:
+      - wpdevnet
+
+    volumes:
+      - ./docker/php-config.ini:/usr/local/etc/php/conf.d/php-config.ini
+      - ./docker/xdebug.ini.disabled:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - ./:/var/www
 
 volumes:
   mysql: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
     profiles: ['cli']
 
-    working_dir: /var/www/src
+    working_dir: /var/www
 
     entrypoint: ['/usr/local/bin/wp', '--allow-root']
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,14 @@
 FROM php:8.3-cli
 
-RUN apt-get update && apt-get install -y libicu-dev libpng-dev libzip-dev unzip
+RUN apt-get update && apt-get install -y default-mysql-client git libicu-dev libpng-dev libzip-dev unzip
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 RUN /usr/local/bin/docker-php-ext-install gd intl mysqli pdo_mysql zip
 
-# COPY docker/worker/php.local.ini /usr/local/etc/php/conf.d/
-
-# COPY docker/xdebug.ini /usr/local/etc/php/conf.d/
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x wp-cli.phar \
+    && mv wp-cli.phar /usr/local/bin/wp
 
 EXPOSE 8889
 WORKDIR /var/www

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:8.3-cli
+
+RUN apt-get update && apt-get install -y libicu-dev libpng-dev libzip-dev unzip
+
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+
+RUN /usr/local/bin/docker-php-ext-install gd intl mysqli pdo_mysql zip
+
+# COPY docker/worker/php.local.ini /usr/local/etc/php/conf.d/
+
+# COPY docker/xdebug.ini /usr/local/etc/php/conf.d/
+
+EXPOSE 8889
+WORKDIR /var/www

--- a/docker/php-config.ini
+++ b/docker/php-config.ini
@@ -1,0 +1,4 @@
+display_errors = On
+error_reporting = -1
+upload_max_filesize = 1G
+post_max_size = 1G

--- a/docker/xdebug.ini
+++ b/docker/xdebug.ini
@@ -1,0 +1,4 @@
+xdebug.mode = develop,debug
+xdebug.start_with_request = yes
+xdeug.start_upon_error = yes
+xdebug.client_host = host.docker.internal

--- a/docker/xdebug.ini.disabled
+++ b/docker/xdebug.ini.disabled
@@ -1,0 +1,1 @@
+#zend_extension=xdebug

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -30,35 +30,4 @@ try {
 }
 
 // Start the local-env containers.
-const containers = ( process.env.LOCAL_PHP_MEMCACHED === 'true' )
-	? 'wordpress-develop memcached'
-	: 'wordpress-develop';
-execSync( `docker compose up -d ${containers}`, { stdio: 'inherit' } );
-
-// If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.
-if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {
-	// VBoxManage is added to the PATH on every platform except Windows.
-	const vboxmanage = process.env.VBOX_MSI_INSTALL_PATH ? `${ process.env.VBOX_MSI_INSTALL_PATH }/VBoxManage` : 'VBoxManage'
-
-	// Check if the port forwarding is already configured for this port.
-	const vminfoBuffer = execSync( `"${ vboxmanage }" showvminfo "${ process.env.DOCKER_MACHINE_NAME }" --machinereadable` );
-	const vminfo = vminfoBuffer.toString().split( /[\r\n]+/ );
-
-	vminfo.forEach( ( info ) => {
-		if ( ! info.startsWith( 'Forwarding' ) ) {
-			return;
-		}
-
-		// `info` is in the format: Forwarding(1)="tcp-port8889,tcp,127.0.0.1,8889,,8889"
-		// Parse it down so `rule` only contains the data inside quotes, split by ','.
-		const rule = info.replace( /(^.*?"|"$)/, '' ).split( ',' );
-
-		// Delete rules that are using the port we need.
-		if ( rule[ 3 ] === process.env.LOCAL_PORT || rule[ 5 ] === process.env.LOCAL_PORT ) {
-			execSync( `"${ vboxmanage }" controlvm "${ process.env.DOCKER_MACHINE_NAME }" natpf1 delete ${ rule[ 0 ] }`, { stdio: 'inherit' } );
-		}
-	} );
-
-	// Add our port forwarding rule.
-	execSync( `"${ vboxmanage }" controlvm "${ process.env.DOCKER_MACHINE_NAME }" natpf1 "tcp-port${ process.env.LOCAL_PORT },tcp,127.0.0.1,${ process.env.LOCAL_PORT },,${ process.env.LOCAL_PORT }"`, { stdio: 'inherit' } );
-}
+execSync( `docker compose up -d`, { stdio: 'inherit' } );


### PR DESCRIPTION
* The new stack dispenses with the nginx container and serves with `php -S` instead.  

* The php containers for the app and wp-cli are now based on the official `php:8.3-cli` images.

* Some features of wordpress-develop's local dev are not yet supported, but will be in a later patch:
	* LOCAL_PHP_MEMCACHED (the hacky memcache extension is not supported in general)
	* LOCAL_DB_TYPE (always uses mysql now)
	* LOCAL_DB_VERSION (always 8.0 now)
	* LOCAL_MULTISITE (need to go back to using wp-cli to serve)

Despite the breakage, I'm moving forward with what I have and will fix these issues later.  waggypuppy's compatibility guarantees don't cover local development workflows.