### PR TITLE
WIP chuck-dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,3 @@
 # Welcome to waggypuppy development!
 
 TODO
-
-# WP developer resources
-
-For the in-depth documentation, please visit the [Contributor Handbook](https://make.wp.org/core/handbook/contribute/).
-
-## First Time?
-
-If this is your first time contributing, you may also find reviewing these guides first to be helpful:
-
-- FAQs for New Contributors: https://make.wp.org/core/handbook/tutorials/faq-for-new-contributors/
-- Contributing with Code Guide: https://make.wp.org/core/handbook/contribute/
-- WP Coding Standards: https://make.wp.org/core/handbook/best-practices/coding-standards/
-- Inline Documentation Standards: https://make.wp.org/core/handbook/best-practices/inline-documentation-standards/
-- Browser Support Policies: https://make.wp.org/core/handbook/best-practices/browser-support/
-- Proper spelling and grammar related best practices: https://make.wp.org/core/handbook/best-practices/spelling/

--- a/INCOMPATIBILITIES.md
+++ b/INCOMPATIBILITIES.md
@@ -1,0 +1,5 @@
+# Incompatabilities with WordPress
+
+TODO
+
+Incompatibilities with upstream will be documented here.

--- a/INCOMPATIBILITIES.md
+++ b/INCOMPATIBILITIES.md
@@ -1,5 +1,5 @@
 # Incompatabilities with WordPress
 
-TODO
+## News and Events widget removed from admin dashboard
 
-Incompatibilities with upstream will be documented here.
+For now it's simply commented out, but there's not much reason to keep the implementation around when there's a generic RSS widget available.

--- a/meta/bin/fixup-config
+++ b/meta/bin/fixup-config
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. $(dirname $0)/prelude.bash
+
+exec php meta/bin/fixup-config.php "$@"

--- a/meta/bin/fixup-config.php
+++ b/meta/bin/fixup-config.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+// From https://github.com/wp-cli/config-command/blob/main/src/Config_Command.php
+const VALID_KEY_CHARACTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_ []{}<>~`+=,.;:/?|';
+
+function generate_salt(): string
+{
+    $out = '';
+    foreach ([
+                 'AUTH_KEY',
+                 'SECURE_AUTH_KEY',
+                 'LOGGED_IN_KEY',
+                 'NONCE_KEY',
+                 'AUTH_SALT',
+                 'SECURE_AUTH_SALT',
+                 'LOGGED_IN_SALT',
+                 'NONCE_SALT',
+             ] as $name) {
+        $out .= sprintf("const %-20s = '%s';\n", $name, unique_key());
+    }
+    return $out;
+}
+
+function unique_key(int $length = 64): string
+{
+    $chars = VALID_KEY_CHARACTERS;
+    $key = '';
+    $len = strlen($chars) - 1;
+
+    for ($i = 0; $i < $length; $i++) {
+        $key .= $chars[random_int(0, $len)];
+    }
+
+    return $key;
+}
+
+$file = $argv[1] ?? 'wp-config.php';
+
+$contents = file_get_contents($file);
+$salt = generate_salt();
+$contents = preg_replace('/^## BEGIN: keys.*## END: keys/sm', "## BEGIN: keys\n{$salt}## END: keys", $contents);
+
+file_put_contents($file, $contents);

--- a/meta/bin/install
+++ b/meta/bin/install
@@ -2,16 +2,14 @@
 
 . $(dirname $0)/prelude.bash
 
-wp config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --path=/var/www/src --force
+function secret() {
+    php -r 'echo bin2hex(random_bytes(32));'
+}
 
-wp config set WP_DEBUG ${LOCAL_WP_DEBUG:-true} --raw --type=constant
-wp config set WP_DEBUG_LOG ${LOCAL_WP_DEBUG_LOG:-true} --raw --type=constant
-wp config set WP_DEBUG_DISPLAY ${LOCAL_WP_DEBUG_DISPLAY:-true} --raw --type=constant
-wp config set SCRIPT_DEBUG ${LOCAL_SCRIPT_DEBUG:-true} --raw --type=constant
-wp config set WP_ENVIRONMENT_TYPE ${LOCAL_WP_ENVIRONMENT_TYPE:-local} --type=constant
-wp config set WP_DEVELOPMENT_MODE ${LOCAL_WP_DEVELOPMENT_MODE:-core} --type=constant
+cp wp-config-dev.php wp-config.php
 
-mv src/wp-config.php wp-config.php
+php meta/bin/fixup-config.php
+
 cp wp-tests-config-sample.php wp-tests-config.php
 
 wp db reset --yes

--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -383,7 +383,7 @@ window.wp = window.wp || {};
 			request: {},
 		},
 
-		// Send request to api.waggypuppy.org/themes.
+		// Send request to api.aspirecloud.org/themes.
 		apiCall: function ( request, paginated ) {
 			return wp.ajax.send( 'query-themes', {
 				data: {
@@ -1765,7 +1765,7 @@ window.wp = window.wp || {};
 			);
 			$( '.drawer-toggle' ).attr( 'aria-expanded', 'false' );
 
-			// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
+			// Get the themes by sending Ajax POST request to api.aspirecloud.org/themes
 			// or searching the local cache.
 			this.collection.query( request );
 
@@ -1875,7 +1875,7 @@ window.wp = window.wp || {};
 			// Create a new collection with the proper theme data
 			// for each section.
 			if ( 'block-themes' === section ) {
-				// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
+				// Get the themes by sending Ajax POST request to api.aspirecloud.org/themes
 				// or searching the local cache.
 				this.collection.query( { tag: 'full-site-editing' } );
 			} else {
@@ -1954,7 +1954,7 @@ window.wp = window.wp || {};
 			filter = _.union( [ filter, this.filtersChecked() ] );
 			request = { tag: [ filter ] };
 
-			// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
+			// Get the themes by sending Ajax POST request to api.aspirecloud.org/themes
 			// or searching the local cache.
 			this.collection.query( request );
 		},
@@ -1992,7 +1992,7 @@ window.wp = window.wp || {};
 				filteringBy.append( '<span class="tag">' + name + '</span>' );
 			} );
 
-			// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
+			// Get the themes by sending Ajax POST request to api.aspirecloud.org/themes
 			// or searching the local cache.
 			this.collection.query( request );
 		},
@@ -2019,7 +2019,7 @@ window.wp = window.wp || {};
 					username: username,
 				},
 				success: function () {
-					// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
+					// Get the themes by sending Ajax POST request to api.aspirecloud.org/themes
 					// or searching the local cache.
 					that.collection.query( request );
 				},

--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -383,7 +383,7 @@ window.wp = window.wp || {};
 			request: {},
 		},
 
-		// Send request to api.wp.org/themes.
+		// Send request to api.waggypuppy.org/themes.
 		apiCall: function ( request, paginated ) {
 			return wp.ajax.send( 'query-themes', {
 				data: {
@@ -1765,7 +1765,7 @@ window.wp = window.wp || {};
 			);
 			$( '.drawer-toggle' ).attr( 'aria-expanded', 'false' );
 
-			// Get the themes by sending Ajax POST request to api.wp.org/themes
+			// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
 			// or searching the local cache.
 			this.collection.query( request );
 
@@ -1875,7 +1875,7 @@ window.wp = window.wp || {};
 			// Create a new collection with the proper theme data
 			// for each section.
 			if ( 'block-themes' === section ) {
-				// Get the themes by sending Ajax POST request to api.wp.org/themes
+				// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
 				// or searching the local cache.
 				this.collection.query( { tag: 'full-site-editing' } );
 			} else {
@@ -1954,7 +1954,7 @@ window.wp = window.wp || {};
 			filter = _.union( [ filter, this.filtersChecked() ] );
 			request = { tag: [ filter ] };
 
-			// Get the themes by sending Ajax POST request to api.wp.org/themes
+			// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
 			// or searching the local cache.
 			this.collection.query( request );
 		},
@@ -1992,7 +1992,7 @@ window.wp = window.wp || {};
 				filteringBy.append( '<span class="tag">' + name + '</span>' );
 			} );
 
-			// Get the themes by sending Ajax POST request to api.wp.org/themes
+			// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
 			// or searching the local cache.
 			this.collection.query( request );
 		},
@@ -2019,7 +2019,7 @@ window.wp = window.wp || {};
 					username: username,
 				},
 				success: function () {
-					// Get the themes by sending Ajax POST request to api.wp.org/themes
+					// Get the themes by sending Ajax POST request to api.waggypuppy.org/themes
 					// or searching the local cache.
 					that.collection.query( request );
 				},

--- a/src/wp-admin/_index.php
+++ b/src/wp-admin/_index.php
@@ -116,11 +116,12 @@ if (is_blog_admin() && current_user_can('edit_posts')) {
         . '</p>';
 }
 
-$help .= '<p>' . sprintf(
-    /* translators: %s: WP Planet URL. */
-        __('<strong>WP Events and News</strong> &mdash; Upcoming events near you as well as the latest news from the official WordPress project and the <a href="%s">WordPress Planet</a>.'),
-        __('https://planet.wp.org/'),
-    ) . '</p>';
+// [waggypuppy 2024-10-12] news widget is no longer on the dashboard
+// $help .= '<p>' . sprintf(
+//     /* translators: %s: WP Planet URL. */
+//         __('<strong>WP Events and News</strong> &mdash; Upcoming events near you as well as the latest news from the official WordPress project and the <a href="%s">WordPress Planet</a>.'),
+//         __('https://planet.wp.org/'),
+//     ) . '</p>';
 
 $screen->add_help_tab(
     [

--- a/src/wp-admin/_index.php
+++ b/src/wp-admin/_index.php
@@ -162,7 +162,7 @@ $screen->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>'
     .
     '<p>'

--- a/src/wp-admin/comment.php
+++ b/src/wp-admin/comment.php
@@ -81,7 +81,7 @@ switch ($action) {
             . '</p>'
             .
             '<p>'
-            . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+            . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
             . '</p>',
         );
 

--- a/src/wp-admin/edit-comments.php
+++ b/src/wp-admin/edit-comments.php
@@ -261,7 +261,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -345,7 +345,7 @@ if ('post' === $post_type) {
         . '</p>'
         .
         '<p>'
-        . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+        . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
         . '</p>',
     );
 } elseif ('page' === $post_type) {
@@ -379,7 +379,7 @@ if ('post' === $post_type) {
         . '</p>'
         .
         '<p>'
-        . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+        . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
         . '</p>',
     );
 } elseif ('attachment' === $post_type) {
@@ -416,7 +416,7 @@ if ('post' === $post_type) {
         . '</p>'
         .
         '<p>'
-        . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+        . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
         . '</p>',
     );
 }

--- a/src/wp-admin/edit-link-form.php
+++ b/src/wp-admin/edit-link-form.php
@@ -82,7 +82,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
     '<p><strong>' . __('For more information:') . '</strong></p>' .
     '<p>' . __('<a href="https://codex.wp.org/Links_Add_New_Screen">Documentation on Creating Links</a>') . '</p>' .
-    '<p>' . __('<a href="https://wp.org/support/forums/">Support forums</a>') . '</p>',
+    '<p>' . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>') . '</p>',
 );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';

--- a/src/wp-admin/edit-tags.php
+++ b/src/wp-admin/edit-tags.php
@@ -336,7 +336,7 @@ if ('category' === $taxonomy || 'link_category' === $taxonomy || 'post_tag' === 
             . '</p>';
     }
 
-    $help .= '<p>' . __('<a href="https://wp.org/support/forums/">Support forums</a>') . '</p>';
+    $help .= '<p>' . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>') . '</p>';
 
     get_current_screen()->set_help_sidebar($help);
 

--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -357,7 +357,7 @@ if ('post' === $post_type) {
         . '</p>'
         .
         '<p>'
-        . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+        . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
         . '</p>',
     );
 } elseif ('page' === $post_type) {
@@ -396,7 +396,7 @@ if ('post' === $post_type) {
         . '</p>'
         .
         '<p>'
-        . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+        . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
         . '</p>',
     );
 }

--- a/src/wp-admin/erase-personal-data.php
+++ b/src/wp-admin/erase-personal-data.php
@@ -104,7 +104,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/export-personal-data.php
+++ b/src/wp-admin/export-personal-data.php
@@ -104,7 +104,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/export.php
+++ b/src/wp-admin/export.php
@@ -77,7 +77,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -130,7 +130,7 @@ class Custom_Background
             . '</p>'
             .
             '<p>'
-            . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+            . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
             . '</p>',
         );
 

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -178,7 +178,7 @@ class Custom_Image_Header
             . '</p>'
             .
             '<p>'
-            . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+            . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
             . '</p>',
         );
     }

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -1063,7 +1063,7 @@ class WP_Automatic_Updater
             // Add a note about the support forums.
             $body .= "\n\n"
                 . __('If you experience any issues or need support, the volunteers in the wp.org support forums may be able to help.');
-            $body .= "\n" . __('https://wp.org/support/forums/');
+            $body .= "\n" . __('https://waggypuppy.org/support/forums/');
         }
 
         // Updates are important!
@@ -1505,7 +1505,7 @@ class WP_Automatic_Updater
 
         // Add a note about the support forums.
         $body[] = __('If you experience any issues or need support, the volunteers in the wp.org support forums may be able to help.');
-        $body[] = __('https://wp.org/support/forums/');
+        $body[] = __('https://waggypuppy.org/support/forums/');
         $body[] = "\n" . __('The waggypuppy Team');
 
         if ('' !== get_option('blogname')) {

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -10,7 +10,7 @@
 /**
  * Class WP_Community_Events.
  *
- * A client for api.waggypuppy.org/events.
+ * A client for api.aspirecloud.org/events.
  *
  * @since 4.8.0
  */
@@ -69,7 +69,7 @@ class WP_Community_Events
      * with nearby events.
      *
      * The browser's request for events is proxied with this method, rather
-     * than having the browser make the request directly to api.waggypuppy.org,
+     * than having the browser make the request directly to api.aspirecloud.org,
      * because it allows results to be cached server-side and shared with other
      * users and sites in the network. This makes the process more efficient,
      * since increasing the number of visits that get cached data means users
@@ -101,7 +101,7 @@ class WP_Community_Events
         // Include an unmodified $wp_version.
         require ABSPATH . WPINC . '/version.php';
 
-        $api_url = 'http://api.waggypuppy.org/events/1.0/';
+        $api_url = wpup_api_url('/events/1.0/');
         $request_args = $this->get_request_args($location_search, $timezone);
         $request_args['user-agent'] = 'WordPress/' . $wp_version . '; ' . home_url('/');
 

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -10,7 +10,7 @@
 /**
  * Class WP_Community_Events.
  *
- * A client for api.wp.org/events.
+ * A client for api.waggypuppy.org/events.
  *
  * @since 4.8.0
  */
@@ -69,7 +69,7 @@ class WP_Community_Events
      * with nearby events.
      *
      * The browser's request for events is proxied with this method, rather
-     * than having the browser make the request directly to api.wp.org,
+     * than having the browser make the request directly to api.waggypuppy.org,
      * because it allows results to be cached server-side and shared with other
      * users and sites in the network. This makes the process more efficient,
      * since increasing the number of visits that get cached data means users
@@ -101,7 +101,7 @@ class WP_Community_Events
         // Include an unmodified $wp_version.
         require ABSPATH . WPINC . '/version.php';
 
-        $api_url = 'http://api.wp.org/events/1.0/';
+        $api_url = 'http://api.waggypuppy.org/events/1.0/';
         $request_args = $this->get_request_args($location_search, $timezone);
         $request_args['user-agent'] = 'WordPress/' . $wp_version . '; ' . home_url('/');
 

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -908,20 +908,8 @@ class WP_Site_Health
                 'color' => 'blue',
             ],
             'description' => sprintf(
-                '<p>%s</p><p>%s</p>',
+                '<p>%s</p>',
                 __('PHP modules perform most of the tasks on the server that make your site run. Any changes to these must be made by your server administrator.'),
-                sprintf(
-                /* translators: 1: Link to the hosting group page about recommended PHP modules. 2: Additional link attributes. 3: Accessibility text. */
-                    __('The waggypuppy Hosting Team maintains a list of those modules, both recommended and required, in <a href="%1$s" %2$s>the team handbook%3$s</a>.'),
-                    /* translators: Localized team handbook, if one exists. */
-                    esc_url(__('https://make.wp.org/hosting/handbook/handbook/server-environment/#php-extensions')),
-                    'target="_blank"',
-                    sprintf(
-                        '<span class="screen-reader-text"> %s</span><span aria-hidden="true" class="dashicons dashicons-external"></span>',
-                        /* translators: Hidden accessibility text. */
-                        __('(opens in a new tab)'),
-                    ),
-                ),
             ),
             'actions' => '',
             'test' => 'php_extensions',

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1364,7 +1364,7 @@ class WP_Site_Health
             $result['actions'] = sprintf(
                 '<p><a href="%s" target="_blank">%s<span class="screen-reader-text"> %s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
                 /* translators: Localized Support reference. */
-                esc_url(__('https://wp.org/support/forums/')),
+                esc_url(__('https://waggypuppy.org/support/forums/')),
                 __('Get help resolving this issue.'),
                 /* translators: Hidden accessibility text. */
                 __('(opens in a new tab)'),

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1322,7 +1322,7 @@ class WP_Site_Health
         ];
 
         $wp_dotorg = wp_remote_get(
-            'https://api.waggypuppy.org',
+            wpup_api_url(),
             [
                 'timeout' => 10,
             ],
@@ -1343,7 +1343,7 @@ class WP_Site_Health
                     sprintf(
                     /* translators: 1: The IP address wp.org resolves to. 2: The error returned by the lookup. */
                         __('Your site is unable to reach wp.org at %1$s, and returned the error: %2$s'),
-                        gethostbyname('api.waggypuppy.org'),
+                        gethostbyname(parse_url(wpup_api_url(), PHP_URL_HOST)),
                         $wp_dotorg->get_error_message(),
                     ),
                 ),

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1334,7 +1334,7 @@ class WP_Site_Health
         ];
 
         $wp_dotorg = wp_remote_get(
-            'https://api.wp.org',
+            'https://api.waggypuppy.org',
             [
                 'timeout' => 10,
             ],
@@ -1355,7 +1355,7 @@ class WP_Site_Health
                     sprintf(
                     /* translators: 1: The IP address wp.org resolves to. 2: The error returned by the lookup. */
                         __('Your site is unable to reach wp.org at %1$s, and returned the error: %2$s'),
-                        gethostbyname('api.wp.org'),
+                        gethostbyname('api.waggypuppy.org'),
                         $wp_dotorg->get_error_message(),
                     ),
                 ),

--- a/src/wp-admin/includes/credits.php
+++ b/src/wp-admin/includes/credits.php
@@ -33,7 +33,7 @@ function wp_credits($version = '', $locale = '')
         || str_contains($version, '-')
         || (isset($results['data']['version']) && !str_starts_with($version, $results['data']['version']))
     ) {
-        $url = "http://api.wp.org/core/credits/1.1/?version={$version}&locale={$locale}";
+        $url = "http://api.waggypuppy.org/core/credits/1.1/?version={$version}&locale={$locale}";
         $options = ['user-agent' => 'WordPress/' . $version . '; ' . home_url('/')];
 
         if (wp_http_supports(['ssl'])) {

--- a/src/wp-admin/includes/credits.php
+++ b/src/wp-admin/includes/credits.php
@@ -33,7 +33,7 @@ function wp_credits($version = '', $locale = '')
         || str_contains($version, '-')
         || (isset($results['data']['version']) && !str_starts_with($version, $results['data']['version']))
     ) {
-        $url = "http://api.waggypuppy.org/core/credits/1.1/?version={$version}&locale={$locale}";
+        $url = wpup_api_url("/core/credits/1.1/?version={$version}&locale={$locale}");
         $options = ['user-agent' => 'WordPress/' . $version . '; ' . home_url('/')];
 
         if (wp_http_supports(['ssl'])) {

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1883,7 +1883,7 @@ function wp_check_browser_version()
     $response = get_site_transient('browser_' . $key);
 
     if (false === $response) {
-        $url = 'http://api.wp.org/core/browse-happy/1.1/';
+        $url = 'http://api.waggypuppy.org/core/browse-happy/1.1/';
         $options = [
             'body' => ['useragent' => $_SERVER['HTTP_USER_AGENT']],
             'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url('/'),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1883,7 +1883,7 @@ function wp_check_browser_version()
     $response = get_site_transient('browser_' . $key);
 
     if (false === $response) {
-        $url = 'http://api.waggypuppy.org/core/browse-happy/1.1/';
+        $url = wpup_api_url('/core/browse-happy/1.1/');
         $options = [
             'body' => ['useragent' => $_SERVER['HTTP_USER_AGENT']],
             'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url('/'),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -93,7 +93,8 @@ function wp_dashboard_setup()
     }
 
     // WP Events and News.
-    wp_add_dashboard_widget('dashboard_primary', __('WP Events and News'), 'wp_dashboard_events_news');
+    // [waggypuppy 2024-10-12] no longer accepting propaganda from upstream
+    // wp_add_dashboard_widget('dashboard_primary', __('WP Events and News'), 'wp_dashboard_events_news');
 
     if (is_network_admin()) {
         /**

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -152,7 +152,7 @@ function wp_get_popular_importers()
                 'locale' => $locale,
                 'version' => wp_get_wp_version(),
             ],
-            'http://api.wp.org/core/importers/1.1/',
+            'http://api.waggypuppy.org/core/importers/1.1/',
         );
         $options = ['user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url('/')];
 

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -152,7 +152,7 @@ function wp_get_popular_importers()
                 'locale' => $locale,
                 'version' => wp_get_wp_version(),
             ],
-            'http://api.waggypuppy.org/core/importers/1.1/',
+            wpup_api_url('/core/importers/1.1/'),
         );
         $options = ['user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url('/')];
 

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1653,7 +1653,7 @@ function wp_check_php_version()
     $response = get_site_transient('php_check_' . $key);
 
     if (false === $response) {
-        $url = 'http://api.wp.org/core/serve-happy/1.0/';
+        $url = 'http://api.waggypuppy.org/core/serve-happy/1.0/';
 
         if (wp_http_supports(['ssl'])) {
             $url = set_url_scheme($url, 'https');

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1653,7 +1653,7 @@ function wp_check_php_version()
     $response = get_site_transient('php_check_' . $key);
 
     if (false === $response) {
-        $url = 'http://api.waggypuppy.org/core/serve-happy/1.0/';
+        $url = wpup_api_url('/core/serve-happy/1.0/');
 
         if (wp_http_supports(['ssl'])) {
             $url = set_url_scheme($url, 'https');

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -579,7 +579,7 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 
         if (!empty($keys_salts)) {
             $keys_salts_str = '';
-            $from_api = wp_remote_get('https://api.wp.org/secret-key/1.1/salt/');
+            $from_api = wp_remote_get('https://api.waggypuppy.org/secret-key/1.1/salt/');
             if (is_wp_error($from_api)) {
                 foreach ($keys_salts as $c => $v) {
                     $keys_salts_str .= "\ndefine( '$c', '" . wp_generate_password(64, true, true) . "' );";

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -579,7 +579,7 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 
         if (!empty($keys_salts)) {
             $keys_salts_str = '';
-            $from_api = wp_remote_get('https://api.waggypuppy.org/secret-key/1.1/salt/');
+            $from_api = wp_remote_get(wpup_api_url('/secret-key/1.1/salt/'));
             if (is_wp_error($from_api)) {
                 foreach ($keys_salts as $c => $v) {
                     $keys_salts_str .= "\ndefine( '$c', '" . wp_generate_password(64, true, true) . "' );";

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -146,7 +146,7 @@ function plugins_api($action, $args = [])
     $res = apply_filters('plugins_api', false, $action, $args);
 
     if (false === $res) {
-        $url = 'http://api.waggypuppy.org/plugins/info/1.2/';
+        $url = wpup_api_url('/plugins/info/1.2/');
         $url = add_query_arg(
             [
                 'action' => $action,

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -174,7 +174,7 @@ function plugins_api($action, $args = [])
                     sprintf(
                     /* translators: %s: Support forums URL. */
                         __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                        __('https://wp.org/support/forums/'),
+                        __('https://waggypuppy.org/support/forums/'),
                     )
                     . ' '
                     . __('(waggypuppy could not establish a secure connection to wp.org. Please contact your server administrator.)'),
@@ -191,7 +191,7 @@ function plugins_api($action, $args = [])
                 sprintf(
                 /* translators: %s: Support forums URL. */
                     __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                    __('https://wp.org/support/forums/'),
+                    __('https://waggypuppy.org/support/forums/'),
                 ),
                 $request->get_error_message(),
             );
@@ -206,7 +206,7 @@ function plugins_api($action, $args = [])
                     sprintf(
                     /* translators: %s: Support forums URL. */
                         __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                        __('https://wp.org/support/forums/'),
+                        __('https://waggypuppy.org/support/forums/'),
                     ),
                     wp_remote_retrieve_body($request),
                 );

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -146,7 +146,7 @@ function plugins_api($action, $args = [])
     $res = apply_filters('plugins_api', false, $action, $args);
 
     if (false === $res) {
-        $url = 'http://api.wp.org/plugins/info/1.2/';
+        $url = 'http://api.waggypuppy.org/plugins/info/1.2/';
         $url = add_query_arg(
             [
                 'action' => $action,

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -585,7 +585,7 @@ function themes_api($action, $args = [])
                     sprintf(
                     /* translators: %s: Support forums URL. */
                         __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                        __('https://wp.org/support/forums/'),
+                        __('https://waggypuppy.org/support/forums/'),
                     )
                     . ' '
                     . __('(waggypuppy could not establish a secure connection to wp.org. Please contact your server administrator.)'),
@@ -601,7 +601,7 @@ function themes_api($action, $args = [])
                 sprintf(
                 /* translators: %s: Support forums URL. */
                     __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                    __('https://wp.org/support/forums/'),
+                    __('https://waggypuppy.org/support/forums/'),
                 ),
                 $request->get_error_message(),
             );
@@ -616,7 +616,7 @@ function themes_api($action, $args = [])
                     sprintf(
                     /* translators: %s: Support forums URL. */
                         __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                        __('https://wp.org/support/forums/'),
+                        __('https://waggypuppy.org/support/forums/'),
                     ),
                     wp_remote_retrieve_body($request),
                 );

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -557,7 +557,7 @@ function themes_api($action, $args = [])
     $res = apply_filters('themes_api', false, $action, $args);
 
     if (!$res) {
-        $url = 'http://api.waggypuppy.org/themes/info/1.2/';
+        $url = wpup_api_url('/themes/info/1.2/');
         $url = add_query_arg(
             [
                 'action' => $action,

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -557,7 +557,7 @@ function themes_api($action, $args = [])
     $res = apply_filters('themes_api', false, $action, $args);
 
     if (!$res) {
-        $url = 'http://api.wp.org/themes/info/1.2/';
+        $url = 'http://api.waggypuppy.org/themes/info/1.2/';
         $url = add_query_arg(
             [
                 'action' => $action,

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -79,7 +79,7 @@ function translations_api($type, $args = null)
                 sprintf(
                 /* translators: %s: Support forums URL. */
                     __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                    __('https://wp.org/support/forums/'),
+                    __('https://waggypuppy.org/support/forums/'),
                 )
                 . ' '
                 . __('(waggypuppy could not establish a secure connection to wp.org. Please contact your server administrator.)'),
@@ -95,7 +95,7 @@ function translations_api($type, $args = null)
                 sprintf(
                 /* translators: %s: Support forums URL. */
                     __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                    __('https://wp.org/support/forums/'),
+                    __('https://waggypuppy.org/support/forums/'),
                 ),
                 $request->get_error_message(),
             );
@@ -107,7 +107,7 @@ function translations_api($type, $args = null)
                     sprintf(
                     /* translators: %s: Support forums URL. */
                         __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                        __('https://wp.org/support/forums/'),
+                        __('https://waggypuppy.org/support/forums/'),
                     ),
                     wp_remote_retrieve_body($request),
                 );

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -51,7 +51,7 @@ function translations_api($type, $args = null)
     $res = apply_filters('translations_api', false, $type, $args);
 
     if (false === $res) {
-        $url = 'http://api.wp.org/translations/' . $type . '/1.0/';
+        $url = 'http://api.waggypuppy.org/translations/' . $type . '/1.0/';
         $http_url = $url;
         $ssl = wp_http_supports(['ssl']);
         if ($ssl) {

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -51,7 +51,7 @@ function translations_api($type, $args = null)
     $res = apply_filters('translations_api', false, $type, $args);
 
     if (false === $res) {
-        $url = 'http://api.waggypuppy.org/translations/' . $type . '/1.0/';
+        $url = wpup_api_url('/translations/' . $type . '/1.0/');
         $http_url = $url;
         $ssl = wp_http_supports(['ssl']);
         if ($ssl) {

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -133,7 +133,7 @@ function find_core_auto_update()
  */
 function get_core_checksums($version, $locale)
 {
-    $http_url = 'http://api.wp.org/core/checksums/1.0/?' . http_build_query(compact('version', 'locale'), '', '&');
+    $http_url = 'http://api.waggypuppy.org/core/checksums/1.0/?' . http_build_query(compact('version', 'locale'), '', '&');
     $url = $http_url;
 
     $ssl = wp_http_supports(['ssl']);

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -154,7 +154,7 @@ function get_core_checksums($version, $locale)
             sprintf(
             /* translators: %s: Support forums URL. */
                 __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                __('https://wp.org/support/forums/'),
+                __('https://waggypuppy.org/support/forums/'),
             )
             . ' '
             . __('(waggypuppy could not establish a secure connection to wp.org. Please contact your server administrator.)'),

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -133,7 +133,7 @@ function find_core_auto_update()
  */
 function get_core_checksums($version, $locale)
 {
-    $http_url = 'http://api.waggypuppy.org/core/checksums/1.0/?' . http_build_query(compact('version', 'locale'), '', '&');
+    $http_url = wpup_api_url('/core/checksums/1.0/?' . http_build_query(compact('version', 'locale'), '', '&'));
     $url = $http_url;
 
     $ssl = wp_http_supports(['ssl']);

--- a/src/wp-admin/link-manager.php
+++ b/src/wp-admin/link-manager.php
@@ -87,7 +87,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
     '<p><strong>' . __('For more information:') . '</strong></p>' .
     '<p>' . __('<a href="https://codex.wp.org/Links_Screen">Documentation on Managing Links</a>') . '</p>' .
-    '<p>' . __('<a href="https://wp.org/support/forums/">Support forums</a>') . '</p>',
+    '<p>' . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>') . '</p>',
 );
 
 get_current_screen()->set_screen_reader_content(

--- a/src/wp-admin/maint/repair.php
+++ b/src/wp-admin/maint/repair.php
@@ -91,7 +91,7 @@ if (!defined('WP_ALLOW_REPAIR') || !WP_ALLOW_REPAIR) {
         /* translators: 1: wp-config.php, 2: Secret key service URL. */
         echo '<p>'
             . sprintf(__('While you are editing your %1$s file, take a moment to make sure you have all 8 keys and that they are unique. You can generate these using the <a href="%2$s">wp.org secret key service</a>.'),
-                '<code>wp-config.php</code>', 'https://api.waggypuppy.org/secret-key/1.1/salt/')
+                '<code>wp-config.php</code>', wpup_api_url('/secret-key/1.1/salt/'))
             . '</p>';
     }
 } elseif (isset($_GET['repair'])) {

--- a/src/wp-admin/maint/repair.php
+++ b/src/wp-admin/maint/repair.php
@@ -91,7 +91,7 @@ if (!defined('WP_ALLOW_REPAIR') || !WP_ALLOW_REPAIR) {
         /* translators: 1: wp-config.php, 2: Secret key service URL. */
         echo '<p>'
             . sprintf(__('While you are editing your %1$s file, take a moment to make sure you have all 8 keys and that they are unique. You can generate these using the <a href="%2$s">wp.org secret key service</a>.'),
-                '<code>wp-config.php</code>', 'https://api.wp.org/secret-key/1.1/salt/')
+                '<code>wp-config.php</code>', 'https://api.waggypuppy.org/secret-key/1.1/salt/')
             . '</p>';
     }
 } elseif (isset($_GET['repair'])) {

--- a/src/wp-admin/media-new.php
+++ b/src/wp-admin/media-new.php
@@ -79,7 +79,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/my-sites.php
+++ b/src/wp-admin/my-sites.php
@@ -52,7 +52,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
     '<p><strong>' . __('For more information:') . '</strong></p>' .
     '<p>' . __('<a href="https://codex.wp.org/Dashboard_My_Sites_Screen">Documentation on My Sites</a>') . '</p>' .
-    '<p>' . __('<a href="https://wp.org/support/forums/">Support forums</a>') . '</p>',
+    '<p>' . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>') . '</p>',
 );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';

--- a/src/wp-admin/nav-menus.php
+++ b/src/wp-admin/nav-menus.php
@@ -810,7 +810,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/network.php
+++ b/src/wp-admin/network.php
@@ -116,7 +116,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -94,7 +94,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -370,7 +370,7 @@ get_current_screen()->set_help_sidebar(
     $help_sidebar_autoupdates
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/network/upgrade.php
+++ b/src/wp-admin/network/upgrade.php
@@ -45,7 +45,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -42,7 +42,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -58,7 +58,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
     '<p><strong>' . __('For more information:') . '</strong></p>' .
     '<p>' . __('<a href="https://wp.org/documentation/article/settings-general-screen/">Documentation on General Settings</a>') . '</p>' .
-    '<p>' . __('<a href="https://wp.org/support/forums/">Support forums</a>') . '</p>',
+    '<p>' . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>') . '</p>',
 );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';

--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -52,7 +52,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -98,7 +98,7 @@ if ($is_nginx) {
         . '</p>';
 }
 
-$help_sidebar_content .= '<p>' . __('<a href="https://wp.org/support/forums/">Support forums</a>') . '</p>';
+$help_sidebar_content .= '<p>' . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>') . '</p>';
 
 get_current_screen()->set_help_sidebar($help_sidebar_content);
 unset($help_sidebar_content);

--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -77,7 +77,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -67,7 +67,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -349,7 +349,7 @@ $content = esc_textarea($content);
                     <?php echo $docs_select; ?>
                     <input disabled id="docs-lookup" type="button" class="button"
                            value="<?php esc_attr_e('Look Up'); ?>"
-                           onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.wp.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode(get_user_locale()); ?>&amp;version=<?php echo urlencode(get_bloginfo('version')); ?>&amp;redirect=true'); }"/>
+                           onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.waggypuppy.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode(get_user_locale()); ?>&amp;version=<?php echo urlencode(get_bloginfo('version')); ?>&amp;redirect=true'); }"/>
                 </div>
             <?php endif; ?>
 

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -349,7 +349,7 @@ $content = esc_textarea($content);
                     <?php echo $docs_select; ?>
                     <input disabled id="docs-lookup" type="button" class="button"
                            value="<?php esc_attr_e('Look Up'); ?>"
-                           onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.waggypuppy.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode(get_user_locale()); ?>&amp;version=<?php echo urlencode(get_bloginfo('version')); ?>&amp;redirect=true'); }"/>
+                           onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( '<?= wpup_api_url() ?>/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode(get_user_locale()); ?>&amp;version=<?php echo urlencode(get_bloginfo('version')); ?>&amp;redirect=true'); }"/>
                 </div>
             <?php endif; ?>
 

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -190,7 +190,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -144,7 +144,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -691,7 +691,7 @@ get_current_screen()->set_help_sidebar(
     $help_sidebar_autoupdates
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/revision.php
+++ b/src/wp-admin/revision.php
@@ -167,7 +167,7 @@ $revisions_sidebar = '<p><strong>' . __('For more information:') . '</strong></p
 $revisions_sidebar .= '<p>'
     . __('<a href="https://wp.org/documentation/article/revisions/">Revisions Management</a>')
     . '</p>';
-$revisions_sidebar .= '<p>' . __('<a href="https://wp.org/support/forums/">Support forums</a>') . '</p>';
+$revisions_sidebar .= '<p>' . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>') . '</p>';
 
 get_current_screen()->set_help_sidebar($revisions_sidebar);
 

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -377,7 +377,7 @@ try {
     $no_api = isset($_POST['noapi']);
 
     if (!$no_api) {
-        $secret_keys = wp_remote_get('https://api.wp.org/secret-key/1.1/salt/');
+        $secret_keys = wp_remote_get('https://api.waggypuppy.org/secret-key/1.1/salt/');
     }
 
     if ($no_api || is_wp_error($secret_keys)) {

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -377,7 +377,7 @@ try {
     $no_api = isset($_POST['noapi']);
 
     if (!$no_api) {
-        $secret_keys = wp_remote_get('https://api.waggypuppy.org/secret-key/1.1/salt/');
+        $secret_keys = wp_remote_get(wpup_api_url('/secret-key/1.1/salt/'));
     }
 
     if ($no_api || is_wp_error($secret_keys)) {

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -103,7 +103,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -395,7 +395,7 @@ if ($file_description !== $file_show) {
                         <?php echo $docs_select; ?>
                         <input disabled id="docs-lookup" type="button" class="button"
                                value="<?php esc_attr_e('Look Up'); ?>"
-                               onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.wp.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode(get_user_locale()); ?>&amp;version=<?php echo urlencode(get_bloginfo('version')); ?>&amp;redirect=true'); }"/>
+                               onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.waggypuppy.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode(get_user_locale()); ?>&amp;version=<?php echo urlencode(get_bloginfo('version')); ?>&amp;redirect=true'); }"/>
                     </div>
                 <?php endif; ?>
 

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -395,7 +395,7 @@ if ($file_description !== $file_show) {
                         <?php echo $docs_select; ?>
                         <input disabled id="docs-lookup" type="button" class="button"
                                value="<?php esc_attr_e('Look Up'); ?>"
-                               onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.waggypuppy.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode(get_user_locale()); ?>&amp;version=<?php echo urlencode(get_bloginfo('version')); ?>&amp;redirect=true'); }"/>
+                               onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( '<?= wpup_api_url() ?>/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode(get_user_locale()); ?>&amp;version=<?php echo urlencode(get_bloginfo('version')); ?>&amp;redirect=true'); }"/>
                     </div>
                 <?php endif; ?>
 

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -61,7 +61,7 @@ wp_localize_script(
             'error' => sprintf(
             /* translators: %s: Support forums URL. */
                 __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                __('https://wp.org/support/forums/'),
+                __('https://waggypuppy.org/support/forums/'),
             ),
             'tryAgain' => __('Try Again'),
             /* translators: %d: Number of themes. */
@@ -187,7 +187,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -257,7 +257,7 @@ get_current_screen()->set_help_sidebar(
     $help_sidebar_autoupdates
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/tools.php
+++ b/src/wp-admin/tools.php
@@ -59,7 +59,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
     '<p><strong>' . __('For more information:') . '</strong></p>' .
     '<p>' . __('<a href="https://wp.org/documentation/article/tools-screen/">Documentation on Tools</a>') . '</p>' .
-    '<p>' . __('<a href="https://wp.org/support/forums/">Support forums</a>') . '</p>',
+    '<p>' . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>') . '</p>',
 );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1133,7 +1133,7 @@ get_current_screen()->set_help_sidebar(
     $help_sidebar_autoupdates
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>'
     .
     $help_sidebar_rollback,

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -223,7 +223,7 @@ if ('grid' === $mode) {
         . '</p>'
         .
         '<p>'
-        . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+        . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
         . '</p>',
     );
 
@@ -463,7 +463,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -103,7 +103,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -349,7 +349,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -123,7 +123,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-admin/widgets-form.php
+++ b/src/wp-admin/widgets-form.php
@@ -91,7 +91,7 @@ get_current_screen()->set_help_sidebar(
     . '</p>'
     .
     '<p>'
-    . __('<a href="https://wp.org/support/forums/">Support forums</a>')
+    . __('<a href="https://waggypuppy.org/support/forums/">Support forums</a>')
     . '</p>',
 );
 

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -218,7 +218,7 @@ function wp_admin_bar_wp_menu($wp_admin_bar)
             'parent' => 'wp-logo-external',
             'id' => 'support-forums',
             'title' => __('Support'),
-            'href' => __('https://wp.org/support/forums/'),
+            'href' => __('https://waggypuppy.org/support/forums/'),
         ],
     );
 

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -889,7 +889,7 @@ class WP_Http
      * Determines whether an HTTP API request to the given URL should be blocked.
      *
      * Those who are behind a proxy and want to prevent access to certain hosts may do so. This will
-     * prevent plugins from working and core functionality, if you don't include `api.waggypuppy.org`.
+     * prevent plugins from working and core functionality, if you don't include `api.aspirecloud.org`.
      *
      * You block external URL requests by defining `WP_HTTP_BLOCK_EXTERNAL` as true in your `wp-config.php`
      * file and this will only allow localhost and your site to make requests. The constant

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -889,7 +889,7 @@ class WP_Http
      * Determines whether an HTTP API request to the given URL should be blocked.
      *
      * Those who are behind a proxy and want to prevent access to certain hosts may do so. This will
-     * prevent plugins from working and core functionality, if you don't include `api.wp.org`.
+     * prevent plugins from working and core functionality, if you don't include `api.waggypuppy.org`.
      *
      * You block external URL requests by defining `WP_HTTP_BLOCK_EXTERNAL` as true in your `wp-config.php`
      * file and this will only allow localhost and your site to make requests. The constant

--- a/src/wp-includes/customize/class-wp-customize-themes-section.php
+++ b/src/wp-includes/customize/class-wp-customize-themes-section.php
@@ -92,7 +92,7 @@ class WP_Customize_Themes_Section extends WP_Customize_Section
                             printf(
                             /* translators: %s: Support forums URL. */
                                 __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                                __('https://wp.org/support/forums/'),
+                                __('https://waggypuppy.org/support/forums/'),
                             );
                             ?>
                         </p>

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2504,7 +2504,7 @@ if (!function_exists('wp_salt')) :
      * The secret keys in wp-config.php should be updated to strong, random keys to maximize
      * security. Below is an example of how the secret key constants are defined.
      * Do not paste this example directly into wp-config.php. Instead, have a
-     * {@link https://api.wp.org/secret-key/1.1/salt/ secret key created} just
+     * {@link https://api.waggypuppy.org/secret-key/1.1/salt/ secret key created} just
      * for you.
      *
      *     define('AUTH_KEY',         ' Xakm<o xQy rw4EMsLKM-?!T+,PFF})H4lzcW57AF0U@N@< >M%G4Yt>f`z]MON');
@@ -2523,7 +2523,7 @@ if (!function_exists('wp_salt')) :
      * @return string Salt value
      * @since 2.5.0
      *
-     * @link https://api.wp.org/secret-key/1.1/salt/ Create secrets for wp-config.php
+     * @link https://api.waggypuppy.org/secret-key/1.1/salt/ Create secrets for wp-config.php
      *
      */
     function wp_salt($scheme = 'auth')

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2504,7 +2504,7 @@ if (!function_exists('wp_salt')) :
      * The secret keys in wp-config.php should be updated to strong, random keys to maximize
      * security. Below is an example of how the secret key constants are defined.
      * Do not paste this example directly into wp-config.php. Instead, have a
-     * {@link https://api.waggypuppy.org/secret-key/1.1/salt/ secret key created} just
+     * {@link https://api.aspirecloud.org/secret-key/1.1/salt/ secret key created} just
      * for you.
      *
      *     define('AUTH_KEY',         ' Xakm<o xQy rw4EMsLKM-?!T+,PFF})H4lzcW57AF0U@N@< >M%G4Yt>f`z]MON');
@@ -2523,7 +2523,7 @@ if (!function_exists('wp_salt')) :
      * @return string Salt value
      * @since 2.5.0
      *
-     * @link https://api.waggypuppy.org/secret-key/1.1/salt/ Create secrets for wp-config.php
+     * @link https://api.aspirecloud.org/secret-key/1.1/salt/ Create secrets for wp-config.php
      *
      */
     function wp_salt($scheme = 'auth')

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -10,8 +10,8 @@
 /**
  * Controller which provides REST endpoint for block patterns.
  *
- * This simply proxies the endpoint at http://api.waggypuppy.org/patterns/1.0/. That isn't necessary for
- * functionality, but is desired for privacy. It prevents api.waggypuppy.org from knowing the user's IP address.
+ * This simply proxies the endpoint at http://api.aspirecloud.org/patterns/1.0/. That isn't necessary for
+ * functionality, but is desired for privacy. It prevents api.aspirecloud.org from knowing the user's IP address.
  *
  * @since 5.8.0
  *
@@ -119,7 +119,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller
         $raw_patterns = get_site_transient($transient_key);
 
         if (!$raw_patterns) {
-            $api_url = 'http://api.waggypuppy.org/patterns/1.0/?' . build_query($query_args);
+            $api_url = wpup_api_url('/patterns/1.0/?' . build_query($query_args));
             if (wp_http_supports(['ssl'])) {
                 $api_url = set_url_scheme($api_url, 'https');
             }
@@ -180,7 +180,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller
     /**
      * Prepare a raw block pattern before it gets output in a REST API response.
      *
-     * @param object $item Raw pattern from api.waggypuppy.org, before any changes.
+     * @param object $item Raw pattern from api.aspirecloud.org, before any changes.
      * @param WP_REST_Request $request Request object.
      * @return WP_REST_Response
      * @since 5.9.0 Renamed `$raw_pattern` to `$item` to match parent class for PHP 8 named parameter support.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -144,7 +144,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller
                     sprintf(
                     /* translators: %s: Support forums URL. */
                         __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                        __('https://wp.org/support/forums/'),
+                        __('https://waggypuppy.org/support/forums/'),
                     ),
                     [
                         'response' => wp_remote_retrieve_body($wporg_response),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -10,8 +10,8 @@
 /**
  * Controller which provides REST endpoint for block patterns.
  *
- * This simply proxies the endpoint at http://api.wp.org/patterns/1.0/. That isn't necessary for
- * functionality, but is desired for privacy. It prevents api.wp.org from knowing the user's IP address.
+ * This simply proxies the endpoint at http://api.waggypuppy.org/patterns/1.0/. That isn't necessary for
+ * functionality, but is desired for privacy. It prevents api.waggypuppy.org from knowing the user's IP address.
  *
  * @since 5.8.0
  *
@@ -119,7 +119,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller
         $raw_patterns = get_site_transient($transient_key);
 
         if (!$raw_patterns) {
-            $api_url = 'http://api.wp.org/patterns/1.0/?' . build_query($query_args);
+            $api_url = 'http://api.waggypuppy.org/patterns/1.0/?' . build_query($query_args);
             if (wp_http_supports(['ssl'])) {
                 $api_url = set_url_scheme($api_url, 'https');
             }
@@ -180,7 +180,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller
     /**
      * Prepare a raw block pattern before it gets output in a REST API response.
      *
-     * @param object $item Raw pattern from api.wp.org, before any changes.
+     * @param object $item Raw pattern from api.waggypuppy.org, before any changes.
      * @param WP_REST_Request $request Request object.
      * @return WP_REST_Response
      * @since 5.9.0 Renamed `$raw_pattern` to `$item` to match parent class for PHP 8 named parameter support.

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -210,7 +210,7 @@ function wp_version_check($extra_stats = [], $force_check = false)
             sprintf(
             /* translators: %s: Support forums URL. */
                 __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                __('https://wp.org/support/forums/'),
+                __('https://waggypuppy.org/support/forums/'),
             )
             . ' '
             . __('(waggypuppy could not establish a secure connection to wp.org. Please contact your server administrator.)'),
@@ -449,7 +449,7 @@ function wp_update_plugins($extra_stats = [])
             sprintf(
             /* translators: %s: Support forums URL. */
                 __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                __('https://wp.org/support/forums/'),
+                __('https://waggypuppy.org/support/forums/'),
             )
             . ' '
             . __('(waggypuppy could not establish a secure connection to wp.org. Please contact your server administrator.)'),
@@ -731,7 +731,7 @@ function wp_update_themes($extra_stats = [])
             sprintf(
             /* translators: %s: Support forums URL. */
                 __('An unexpected error occurred. Something may be wrong with wp.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.'),
-                __('https://wp.org/support/forums/'),
+                __('https://waggypuppy.org/support/forums/'),
             )
             . ' '
             . __('(waggypuppy could not establish a secure connection to wp.org. Please contact your server administrator.)'),

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -11,7 +11,7 @@
  *
  * The waggypuppy version, PHP version, and locale is sent.
  *
- * Checks against the waggypuppy server at api.waggypuppy.org. Will only check
+ * Checks against the waggypuppy server at api.aspirecloud.org. Will only check
  * if waggypuppy isn't installing.
  *
  * @param array $extra_stats Extra statistics to report to the wp.org API.
@@ -182,7 +182,7 @@ function wp_version_check($extra_stats = [], $force_check = false)
         $query['channel'] = WP_AUTO_UPDATE_CORE;
     }
 
-    $url = 'http://api.waggypuppy.org/core/version-check/1.7/?' . http_build_query($query, '', '&');
+    $url = wpup_api_url('/core/version-check/1.7/?' . http_build_query($query, '', '&'));
     $http_url = $url;
     $ssl = wp_http_supports(['ssl']);
 
@@ -306,7 +306,7 @@ function wp_version_check($extra_stats = [], $force_check = false)
  *
  * A list of all plugins installed is sent to WP, along with the site locale.
  *
- * Checks against the waggypuppy server at api.waggypuppy.org. Will only check
+ * Checks against the waggypuppy server at api.aspirecloud.org. Will only check
  * if waggypuppy isn't installing.
  *
  * @param array $extra_stats Extra statistics to report to the wp.org API.
@@ -433,7 +433,7 @@ function wp_update_plugins($extra_stats = [])
         $options['body']['update_stats'] = wp_json_encode($extra_stats);
     }
 
-    $url = 'http://api.waggypuppy.org/plugins/update-check/1.1/';
+    $url =  wpup_api_url('/plugins/update-check/1.1/');
     $http_url = $url;
     $ssl = wp_http_supports(['ssl']);
 
@@ -581,7 +581,7 @@ function wp_update_plugins($extra_stats = [])
  *
  * A list of all themes installed is sent to WP, along with the site locale.
  *
- * Checks against the waggypuppy server at api.waggypuppy.org. Will only check
+ * Checks against the waggypuppy server at api.aspirecloud.org. Will only check
  * if waggypuppy isn't installing.
  *
  * @param array $extra_stats Extra statistics to report to the wp.org API.
@@ -715,7 +715,7 @@ function wp_update_themes($extra_stats = [])
         $options['body']['update_stats'] = wp_json_encode($extra_stats);
     }
 
-    $url = 'http://api.waggypuppy.org/themes/update-check/1.1/';
+    $url = wpup_api_url('/themes/update-check/1.1/');
     $http_url = $url;
     $ssl = wp_http_supports(['ssl']);
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -11,7 +11,7 @@
  *
  * The waggypuppy version, PHP version, and locale is sent.
  *
- * Checks against the waggypuppy server at api.wp.org. Will only check
+ * Checks against the waggypuppy server at api.waggypuppy.org. Will only check
  * if waggypuppy isn't installing.
  *
  * @param array $extra_stats Extra statistics to report to the wp.org API.
@@ -182,7 +182,7 @@ function wp_version_check($extra_stats = [], $force_check = false)
         $query['channel'] = WP_AUTO_UPDATE_CORE;
     }
 
-    $url = 'http://api.wp.org/core/version-check/1.7/?' . http_build_query($query, '', '&');
+    $url = 'http://api.waggypuppy.org/core/version-check/1.7/?' . http_build_query($query, '', '&');
     $http_url = $url;
     $ssl = wp_http_supports(['ssl']);
 
@@ -306,7 +306,7 @@ function wp_version_check($extra_stats = [], $force_check = false)
  *
  * A list of all plugins installed is sent to WP, along with the site locale.
  *
- * Checks against the waggypuppy server at api.wp.org. Will only check
+ * Checks against the waggypuppy server at api.waggypuppy.org. Will only check
  * if waggypuppy isn't installing.
  *
  * @param array $extra_stats Extra statistics to report to the wp.org API.
@@ -433,7 +433,7 @@ function wp_update_plugins($extra_stats = [])
         $options['body']['update_stats'] = wp_json_encode($extra_stats);
     }
 
-    $url = 'http://api.wp.org/plugins/update-check/1.1/';
+    $url = 'http://api.waggypuppy.org/plugins/update-check/1.1/';
     $http_url = $url;
     $ssl = wp_http_supports(['ssl']);
 
@@ -581,7 +581,7 @@ function wp_update_plugins($extra_stats = [])
  *
  * A list of all themes installed is sent to WP, along with the site locale.
  *
- * Checks against the waggypuppy server at api.wp.org. Will only check
+ * Checks against the waggypuppy server at api.waggypuppy.org. Will only check
  * if waggypuppy isn't installing.
  *
  * @param array $extra_stats Extra statistics to report to the wp.org API.
@@ -715,7 +715,7 @@ function wp_update_themes($extra_stats = [])
         $options['body']['update_stats'] = wp_json_encode($extra_stats);
     }
 
-    $url = 'http://api.wp.org/themes/update-check/1.1/';
+    $url = 'http://api.waggypuppy.org/themes/update-check/1.1/';
     $http_url = $url;
     $ssl = wp_http_supports(['ssl']);
 

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1396,7 +1396,7 @@ switch ($action) {
                     /* translators: 1: Browser cookie documentation URL, 2: Support forums URL. */
                         __('<strong>Error:</strong> Cookies are blocked due to unexpected output. For help, please see <a href="%1$s">this documentation</a> or try the <a href="%2$s">support forums</a>.'),
                         __('https://developer.wp.org/advanced-administration/wordpress/cookies/'),
-                        __('https://wp.org/support/forums/'),
+                        __('https://waggypuppy.org/support/forums/'),
                     ),
                 );
             } elseif (isset($_POST['testcookie']) && empty($_COOKIE[TEST_COOKIE])) {

--- a/src/wpup.php
+++ b/src/wpup.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+function wpup_api_url(string $path = ''): string {
+    return WPUP_API_URL . $path;
+}

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -14,7 +14,7 @@
 abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
 {
     // You can use your own version of data/WPHTTP-testcase-redirection-script.php here.
-    public $redirection_script = 'http://api.wp.org/core/tests/1.0/redirection.php';
+    public $redirection_script = 'http://api.waggypuppy.org/core/tests/1.0/redirection.php';
     public $file_stream_url = 'http://s.w.org/screenshots/3.9/dashboard.png';
 
     protected $http_request_args;
@@ -224,7 +224,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
      */
     public function test_no_redirection_on_PUT()
     {
-        $url = 'http://api.wp.org/core/tests/1.0/redirection.php?201-location=1';
+        $url = 'http://api.waggypuppy.org/core/tests/1.0/redirection.php?201-location=1';
 
         // Test 301 - POST to POST.
         $res = wp_remote_request(
@@ -377,7 +377,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
      */
     public function test_post_redirect_to_method_300($response_code, $method)
     {
-        $url = 'http://api.wp.org/core/tests/1.0/redirection.php?post-redirect-to-method=1';
+        $url = 'http://api.waggypuppy.org/core/tests/1.0/redirection.php?post-redirect-to-method=1';
 
         $res = wp_remote_post(add_query_arg('response_code', $response_code, $url), ['timeout' => 30]);
 
@@ -422,11 +422,11 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
      */
     public function test_ip_url_with_host_header()
     {
-        $ip = gethostbyname('api.wp.org');
+        $ip = gethostbyname('api.waggypuppy.org');
         $url = 'http://' . $ip . '/core/tests/1.0/redirection.php?print-pass=1';
         $args = [
             'headers' => [
-                'Host' => 'api.wp.org',
+                'Host' => 'api.waggypuppy.org',
             ],
             'timeout' => 30,
             'redirection' => 0,
@@ -474,7 +474,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
      */
     public function test_cookie_handling()
     {
-        $url = 'http://api.wp.org/core/tests/1.0/redirection.php?cookie-test=1';
+        $url = 'http://api.waggypuppy.org/core/tests/1.0/redirection.php?cookie-test=1';
 
         $res = wp_remote_get($url);
 

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -14,7 +14,7 @@
 abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
 {
     // You can use your own version of data/WPHTTP-testcase-redirection-script.php here.
-    public $redirection_script = 'http://api.waggypuppy.org/core/tests/1.0/redirection.php';
+    public $redirection_script = 'http://api.aspirecloud.org/core/tests/1.0/redirection.php';
     public $file_stream_url = 'http://s.w.org/screenshots/3.9/dashboard.png';
 
     protected $http_request_args;
@@ -224,7 +224,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
      */
     public function test_no_redirection_on_PUT()
     {
-        $url = 'http://api.waggypuppy.org/core/tests/1.0/redirection.php?201-location=1';
+        $url = 'http://api.aspirecloud.org/core/tests/1.0/redirection.php?201-location=1';
 
         // Test 301 - POST to POST.
         $res = wp_remote_request(
@@ -377,7 +377,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
      */
     public function test_post_redirect_to_method_300($response_code, $method)
     {
-        $url = 'http://api.waggypuppy.org/core/tests/1.0/redirection.php?post-redirect-to-method=1';
+        $url = 'http://api.aspirecloud.org/core/tests/1.0/redirection.php?post-redirect-to-method=1';
 
         $res = wp_remote_post(add_query_arg('response_code', $response_code, $url), ['timeout' => 30]);
 
@@ -422,11 +422,11 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
      */
     public function test_ip_url_with_host_header()
     {
-        $ip = gethostbyname('api.waggypuppy.org');
+        $ip = gethostbyname('api.aspirecloud.org');
         $url = 'http://' . $ip . '/core/tests/1.0/redirection.php?print-pass=1';
         $args = [
             'headers' => [
-                'Host' => 'api.waggypuppy.org',
+                'Host' => 'api.aspirecloud.org',
             ],
             'timeout' => 30,
             'redirection' => 0,
@@ -474,7 +474,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase
      */
     public function test_cookie_handling()
     {
-        $url = 'http://api.waggypuppy.org/core/tests/1.0/redirection.php?cookie-test=1';
+        $url = 'http://api.aspirecloud.org/core/tests/1.0/redirection.php?cookie-test=1';
 
         $res = wp_remote_get($url);
 

--- a/tests/phpunit/tests/rest-api/rest-block-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-directory-controller.php
@@ -98,7 +98,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
         $request = new WP_REST_Request('GET', '/wp/v2/block-directory/search');
         $request->set_query_params(['term' => 'foo']);
 
-        $this->prevent_requests_to_host('api.wp.org');
+        $this->prevent_requests_to_host('api.waggypuppy.org');
 
         $this->expectWarning();
         $response = rest_do_request($request);
@@ -286,7 +286,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
      * @since 5.5.0
      *
      */
-    private function prevent_requests_to_host($blocked_host = 'api.wp.org')
+    private function prevent_requests_to_host($blocked_host = 'api.waggypuppy.org')
     {
         add_filter(
             'pre_http_request',

--- a/tests/phpunit/tests/rest-api/rest-block-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-directory-controller.php
@@ -98,7 +98,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
         $request = new WP_REST_Request('GET', '/wp/v2/block-directory/search');
         $request->set_query_params(['term' => 'foo']);
 
-        $this->prevent_requests_to_host('api.waggypuppy.org');
+        $this->prevent_requests_to_host('api.aspirecloud.org');
 
         $this->expectWarning();
         $response = rest_do_request($request);
@@ -286,7 +286,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
      * @since 5.5.0
      *
      */
-    private function prevent_requests_to_host($blocked_host = 'api.waggypuppy.org')
+    private function prevent_requests_to_host($blocked_host = 'api.aspirecloud.org')
     {
         add_filter(
             'pre_http_request',

--- a/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
@@ -238,7 +238,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
     public function test_get_items_wdotorg_unavailable()
     {
         wp_set_current_user(self::$contributor_id);
-        self::prevent_requests_to_host('api.waggypuppy.org');
+        self::prevent_requests_to_host('api.aspirecloud.org');
 
         $request = new WP_REST_Request('GET', '/wp/v2/pattern-directory/patterns');
         $response = rest_do_request($request);
@@ -598,7 +598,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
     }
 
     /**
-     * Get a mocked raw response from api.waggypuppy.org.
+     * Get a mocked raw response from api.aspirecloud.org.
      *
      * @return string
      */
@@ -609,22 +609,22 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
         switch ($action) {
             default:
             case 'browse-all':
-                // Response from https://api.waggypuppy.org/patterns/1.0/.
+                // Response from https://api.aspirecloud.org/patterns/1.0/.
                 $response = file_get_contents($fixtures_dir . '/browse-all.json');
                 break;
 
             case 'browse-category':
-                // Response from https://api.waggypuppy.org/patterns/1.0/?pattern-categories=2.
+                // Response from https://api.aspirecloud.org/patterns/1.0/?pattern-categories=2.
                 $response = file_get_contents($fixtures_dir . '/browse-category-2.json');
                 break;
 
             case 'browse-keyword':
-                // Response from https://api.waggypuppy.org/patterns/1.0/?pattern-keywords=11.
+                // Response from https://api.aspirecloud.org/patterns/1.0/?pattern-keywords=11.
                 $response = file_get_contents($fixtures_dir . '/browse-keyword-11.json');
                 break;
 
             case 'search':
-                // Response from https://api.waggypuppy.org/patterns/1.0/?search=button.
+                // Response from https://api.aspirecloud.org/patterns/1.0/?search=button.
                 $response = file_get_contents($fixtures_dir . '/search-button.json');
                 break;
 
@@ -756,7 +756,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
         add_filter(
             'pre_http_request',
             static function ($response, $parsed_args, $url) use ($action, $expects_results) {
-                if ('api.waggypuppy.org' !== wp_parse_url($url, PHP_URL_HOST)) {
+                if ('api.aspirecloud.org' !== wp_parse_url($url, PHP_URL_HOST)) {
                     return $response;
                 }
 
@@ -785,7 +785,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
      * @since 5.8.0
      *
      */
-    private static function prevent_requests_to_host($blocked_host = 'api.waggypuppy.org')
+    private static function prevent_requests_to_host($blocked_host = 'api.aspirecloud.org')
     {
         add_filter(
             'pre_http_request',
@@ -814,7 +814,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
      */
     public function mock_request_to_apiwporg_url($response, $args, $url)
     {
-        if ('api.waggypuppy.org' !== wp_parse_url($url, PHP_URL_HOST)) {
+        if ('api.aspirecloud.org' !== wp_parse_url($url, PHP_URL_HOST)) {
             return $response;
         }
 

--- a/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
@@ -238,7 +238,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
     public function test_get_items_wdotorg_unavailable()
     {
         wp_set_current_user(self::$contributor_id);
-        self::prevent_requests_to_host('api.wp.org');
+        self::prevent_requests_to_host('api.waggypuppy.org');
 
         $request = new WP_REST_Request('GET', '/wp/v2/pattern-directory/patterns');
         $response = rest_do_request($request);
@@ -598,7 +598,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
     }
 
     /**
-     * Get a mocked raw response from api.wp.org.
+     * Get a mocked raw response from api.waggypuppy.org.
      *
      * @return string
      */
@@ -609,22 +609,22 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
         switch ($action) {
             default:
             case 'browse-all':
-                // Response from https://api.wp.org/patterns/1.0/.
+                // Response from https://api.waggypuppy.org/patterns/1.0/.
                 $response = file_get_contents($fixtures_dir . '/browse-all.json');
                 break;
 
             case 'browse-category':
-                // Response from https://api.wp.org/patterns/1.0/?pattern-categories=2.
+                // Response from https://api.waggypuppy.org/patterns/1.0/?pattern-categories=2.
                 $response = file_get_contents($fixtures_dir . '/browse-category-2.json');
                 break;
 
             case 'browse-keyword':
-                // Response from https://api.wp.org/patterns/1.0/?pattern-keywords=11.
+                // Response from https://api.waggypuppy.org/patterns/1.0/?pattern-keywords=11.
                 $response = file_get_contents($fixtures_dir . '/browse-keyword-11.json');
                 break;
 
             case 'search':
-                // Response from https://api.wp.org/patterns/1.0/?search=button.
+                // Response from https://api.waggypuppy.org/patterns/1.0/?search=button.
                 $response = file_get_contents($fixtures_dir . '/search-button.json');
                 break;
 
@@ -756,7 +756,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
         add_filter(
             'pre_http_request',
             static function ($response, $parsed_args, $url) use ($action, $expects_results) {
-                if ('api.wp.org' !== wp_parse_url($url, PHP_URL_HOST)) {
+                if ('api.waggypuppy.org' !== wp_parse_url($url, PHP_URL_HOST)) {
                     return $response;
                 }
 
@@ -785,7 +785,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
      * @since 5.8.0
      *
      */
-    private static function prevent_requests_to_host($blocked_host = 'api.wp.org')
+    private static function prevent_requests_to_host($blocked_host = 'api.waggypuppy.org')
     {
         add_filter(
             'pre_http_request',
@@ -814,7 +814,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
      */
     public function mock_request_to_apiwporg_url($response, $args, $url)
     {
-        if ('api.wp.org' !== wp_parse_url($url, PHP_URL_HOST)) {
+        if ('api.waggypuppy.org' !== wp_parse_url($url, PHP_URL_HOST)) {
             return $response;
         }
 

--- a/tests/phpunit/tests/rest-api/rest-plugins-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-plugins-controller.php
@@ -567,7 +567,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase
         $request = new WP_REST_Request('POST', self::BASE);
         $request->set_body_params(['slug' => 'foo']);
 
-        $this->prevent_requests_to_host('api.wp.org');
+        $this->prevent_requests_to_host('api.waggypuppy.org');
 
         $this->expectWarning();
         $response = rest_do_request($request);
@@ -585,7 +585,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase
             static function () {
                 /*
                  * Mocks the request to:
-                 * https://api.wp.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=alex-says-this-block-definitely-doesnt-exist&request%5Bfields%5D%5Bsections%5D=0&request%5Bfields%5D%5Blanguage_packs%5D=1&request%5Blocale%5D=en_US&request%5Bwp_version%5D=5.9
+                 * https://api.waggypuppy.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=alex-says-this-block-definitely-doesnt-exist&request%5Bfields%5D%5Bsections%5D=0&request%5Bfields%5D%5Blanguage_packs%5D=1&request%5Blocale%5D=en_US&request%5Bwp_version%5D=5.9
                  */
                 return [
                     'headers' => [],
@@ -1237,7 +1237,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase
      * @since 5.5.0
      *
      */
-    private function prevent_requests_to_host($blocked_host = 'api.wp.org')
+    private function prevent_requests_to_host($blocked_host = 'api.waggypuppy.org')
     {
         add_filter(
             'pre_http_request',

--- a/tests/phpunit/tests/rest-api/rest-plugins-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-plugins-controller.php
@@ -567,7 +567,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase
         $request = new WP_REST_Request('POST', self::BASE);
         $request->set_body_params(['slug' => 'foo']);
 
-        $this->prevent_requests_to_host('api.waggypuppy.org');
+        $this->prevent_requests_to_host('api.aspirecloud.org');
 
         $this->expectWarning();
         $response = rest_do_request($request);
@@ -585,7 +585,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase
             static function () {
                 /*
                  * Mocks the request to:
-                 * https://api.waggypuppy.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=alex-says-this-block-definitely-doesnt-exist&request%5Bfields%5D%5Bsections%5D=0&request%5Bfields%5D%5Blanguage_packs%5D=1&request%5Blocale%5D=en_US&request%5Bwp_version%5D=5.9
+                 * https://api.aspirecloud.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=alex-says-this-block-definitely-doesnt-exist&request%5Bfields%5D%5Bsections%5D=0&request%5Bfields%5D%5Blanguage_packs%5D=1&request%5Blocale%5D=en_US&request%5Bwp_version%5D=5.9
                  */
                 return [
                     'headers' => [],
@@ -1237,7 +1237,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase
      * @since 5.5.0
      *
      */
-    private function prevent_requests_to_host($blocked_host = 'api.waggypuppy.org')
+    private function prevent_requests_to_host($blocked_host = 'api.aspirecloud.org')
     {
         add_filter(
             'pre_http_request',

--- a/wp-config-dev.php
+++ b/wp-config-dev.php
@@ -1,0 +1,28 @@
+<?php
+const WP_DEBUG = true;
+
+const DB_NAME = 'wordpress_develop';
+const DB_USER = 'root';
+const DB_PASSWORD = 'password';
+const DB_HOST = 'mysql';
+const DB_CHARSET = 'utf8';
+const DB_COLLATE = '';
+
+$table_prefix = 'wp_';
+
+## BEGIN: keys
+const AUTH_KEY = 'deadbeef';
+const SECURE_AUTH_KEY = 'deadbeef';
+const LOGGED_IN_KEY = 'deadbeef';
+const NONCE_KEY = 'deadbeef';
+const AUTH_SALT = 'deadbeef';
+const SECURE_AUTH_SALT = 'deadbeef';
+const LOGGED_IN_SALT = 'deadbeef';
+const NONCE_SALT = 'deadbeef';
+## END: keys
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+require_once ABSPATH . 'wp-settings.php';

--- a/wp-config-dev.php
+++ b/wp-config-dev.php
@@ -10,6 +10,8 @@ const DB_COLLATE = '';
 
 $table_prefix = 'wp_';
 
+const WPUP_API_URL = 'http://api.aspiredev.org';
+
 ## BEGIN: keys
 const AUTH_KEY = 'deadbeef';
 const SECURE_AUTH_KEY = 'deadbeef';

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -41,7 +41,7 @@ const DB_COLLATE = '';
  * Authentication unique keys and salts.
  *
  * Change these to different unique phrases! You can generate these using
- * the {@link https://api.waggypuppy.org/secret-key/1.1/salt/ wp.org secret-key service}.
+ * the {@link https://api.aspirecloud.org/secret-key/1.1/salt/ wp.org secret-key service}.
  *
  * You can change these at any point in time to invalidate all existing cookies.
  * This will force all users to have to log in again.

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -41,7 +41,7 @@ const DB_COLLATE = '';
  * Authentication unique keys and salts.
  *
  * Change these to different unique phrases! You can generate these using
- * the {@link https://api.wp.org/secret-key/1.1/salt/ wp.org secret-key service}.
+ * the {@link https://api.waggypuppy.org/secret-key/1.1/salt/ wp.org secret-key service}.
  *
  * You can change these at any point in time to invalidate all existing cookies.
  * This will force all users to have to log in again.


### PR DESCRIPTION
🚨 API BROKEN: api.wordpress.org urls are now api.waggypuppy.org.  It's expected a rewrite plugin will fix this, but a config setting will come before that (once I break away from wp-cli for working with config)

* Adds INCOMPATIBILITIES.md
* News widget commented out from dashboard.
* Links to upstream support forum changed to (broken) waggypuppy.org links.  We shouldn't be bothering upstream with questions about our fork.